### PR TITLE
Interface for adaptive BH

### DIFF
--- a/src/MultipleTesting.jl
+++ b/src/MultipleTesting.jl
@@ -11,7 +11,7 @@ export
     PValueAdjustmentMethod,
     Bonferroni,
     BenjaminiHochberg,
-    BenjaminiHochbergOracle,
+    BenjaminiHochbergAdaptive,
     BenjaminiYekutieli,
     Hochberg,
     Holm,
@@ -29,6 +29,7 @@ export
     Storey,
     StoreyBootstrap,
     LeastSlope,
+    Oracle,
     isin
 
 

--- a/src/pi0-estimators.jl
+++ b/src/pi0-estimators.jl
@@ -104,3 +104,18 @@ function lsl_pi0_vec{T<:AbstractFloat}(pValues::Vector{T})
     pi0 = min( 1/s[idx] + 1, n ) / n
     return(pi0)
 end
+
+
+## Oracle
+
+type Oracle <: Pi0Estimator
+    π0::AbstractFloat
+
+    Oracle(π0) = isin(π0, 0., 1.) ? new(π0) : throw(DomainError())
+end
+
+Oracle() = Oracle(1.0)
+
+function estimate_pi0{T<:AbstractFloat}(pValues::Vector{T}, pi0estimator::Oracle)
+    pi0estimator.π0
+end

--- a/src/pval-adjustment.jl
+++ b/src/pval-adjustment.jl
@@ -31,16 +31,19 @@ end
 
 bejamini_hochberg_multiplier(i::Int, n::Int) = n/(n-i)
 
-type BenjaminiHochbergOracle <: PValueAdjustmentMethod
-    π0::Float64
-
-    BenjaminiHochbergOracle(π0) = isin(π0, 0., 1.) ? new(π0) : throw(DomainError())
+type BenjaminiHochbergAdaptive <: PValueAdjustmentMethod
+    pi0estimator::Pi0Estimator
 end
 
 ## default to BenjaminiHochberg
-BenjaminiHochbergOracle() = BenjaminiHochbergOracle(1.0)
+BenjaminiHochbergAdaptive(π0::AbstractFloat) = BenjaminiHochbergAdaptive(Oracle(π0))
 
-adjust(pvals, method::BenjaminiHochbergOracle) = benjamini_hochberg(pvals, method.π0)
+BenjaminiHochbergAdaptive() = BenjaminiHochbergAdaptive(1.0)
+
+function adjust(pvals, method::BenjaminiHochbergAdaptive)
+  π0 = estimate_pi0(pvals, method.pi0estimator)
+  benjamini_hochberg(pvals, π0)
+end
 
 function benjamini_hochberg{T<:AbstractFloat}(pValues::Vector{T}, pi0::T)
     validPValues([pi0])

--- a/test/test-pi0-estimators.jl
+++ b/test/test-pi0-estimators.jl
@@ -103,4 +103,9 @@ p_unsort = unsort(p)
 @test_approx_eq_eps MultipleTesting.lsl_pi0_vec(p_unsort) 0.62 1e-2
 @test !issorted(p_unsort)
 
+## Oracle ##
+println(" ** ", "oracle")
+@test estimate_pi0(p, Oracle(0.5)) == 0.5
+@test estimate_pi0(p0, Oracle(0.6)) == 0.6
+@test estimate_pi0(p1, Oracle()) == 1.0
 end

--- a/test/test-pval-pi0-adjustment.jl
+++ b/test/test-pval-pi0-adjustment.jl
@@ -12,7 +12,7 @@ pi0 = 0.4
 
 ## benjamini_hochberg
 m = benjamini_hochberg
-t = BenjaminiHochbergOracle
+t = BenjaminiHochbergAdaptive
 ref0 = [0.0, 0.0005, 0.003333333, 0.025, 0.1, 0.166666667, 0.285714286, 0.5, 0.833333333, 1.0]
 ref = ref0 .* pi0
 println(" ** ", m)
@@ -31,12 +31,16 @@ pval = rand(1)
 ## compare with reference values
 @test_approx_eq_eps m(pval1, pi0) ref 1e-6
 @test_approx_eq_eps adjust(pval1, t(pi0)) ref 1e-6
-## BHOracle same as BH for π0 missing or 1
+## BH Adaptive same as BH for π0 missing or 1
 @test_approx_eq_eps m(pval1, 1.0) ref0 1e-6
 @test_approx_eq_eps adjust(pval1, t(1.0)) ref0 1e-6
 @test_approx_eq_eps adjust(pval1, t()) ref0 1e-6
 @test_approx_eq_eps adjust(pval1, t(0.0)) zeros(ref0) 1e-6
 
+# adaptive with pi0 estimator == oracle with estimated pi0
+@test adjust(pval1, t(Storey())) == adjust(pval1, t(estimate_pi0(pval1, Storey())))
+@test adjust(pval1, t(Storey(0.3))) == adjust(pval1, t(estimate_pi0(pval1, Storey(0.3))))
+@test adjust(pval1, t(LeastSlope())) == adjust(pval1, t(estimate_pi0(pval1, LeastSlope())))
 
 ## qvalue
 m = qValues


### PR DESCRIPTION
I really like the new interface, it's really clean :D. 

Here is an attempt to make it easy to specify adaptive (sometimes called α-exhaustive) BH procedures. For example now one could do:

```julia
adjust(pv, BenjaminiHochbergAdaptive(0.6)) # oracle procedure
adjust(pv, BenjaminiHochbergAdaptive(Storey())) #adaptive with Storey's estimator
```
This has too many parentheses though. What do you think?

Also, Happy New Year!