### PR TITLE
RightBoundary pi0 estimator

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,12 @@ adjust(pvals, Sidak())
 * Storey's closed-form bootstrap
 * Least SLope (LSL)
 * Two STep (TST)
+* RightBoundary (Storey's estimate with dynamically chosen λ)
 
 ```julia
 estimate_pi0(pvals, Storey())
 estimate_pi0(pvals, StoreyBootstrap())
 estimate_pi0(pvals, LeastSlope())
 estimate_pi0(pvals, TwoStep(0.05))
+estimate_pi0(pvals, RightBoundary())
 ```

--- a/src/MultipleTesting.jl
+++ b/src/MultipleTesting.jl
@@ -10,6 +10,7 @@ export
     bootstrap_pi0,
     lsl_pi0,
     twostep_pi0,
+    rightboundary_pi0,
     adjust,
     PValueAdjustmentMethod,
     Bonferroni,
@@ -36,6 +37,7 @@ export
     LeastSlope,
     Oracle,
     TwoStep,
+    RightBoundary,
     isin
 
 include("types.jl")

--- a/src/pi0-estimators.jl
+++ b/src/pi0-estimators.jl
@@ -165,8 +165,8 @@ function rightboundary_pi0{T<:AbstractFloat}(pValues::Vector{T}, λseq)
     # make sure we catch p-values equal to 1 despite left closure
     # use closed=:left because we have been using >= convention in this package
     # note that original paper uses > convention.
-    h = fit(Histogram, pValues, [λseq; 1.1], closed=:left)
-    pi0_estimates = reverse(cumsum(reverse(h.weights)))./(1. -λseq)./n
+    h = fit(Histogram, pValues, [λseq; Inf], closed=:left)
+    pi0_estimates = reverse(cumsum(reverse(h.weights)))./(1.-λseq)./n
     pi0_decrease = diff(pi0_estimates) .>= 0
     pi0_decrease[end] = true
     pi0 = pi0_estimates[findfirst(pi0_decrease, true) + 1]

--- a/src/pi0-estimators.jl
+++ b/src/pi0-estimators.jl
@@ -137,3 +137,38 @@ function twostep_pi0{T<:AbstractFloat}(pValues::Vector{T}, alpha::T, method::PVa
     pi0 = sum(padj .>= (alpha/(1+alpha))) / length(padj)
     return(pi0)
 end
+
+
+# RightBoundary procedure as defined in Definition 2 of Liang and Nettleton 2012
+# "Adaptive and dynamic adaptive procedures for false discovery rate control and estimation"
+type RightBoundary <: Pi0Estimator
+    ## check range of arguments
+    λseq::Vector{Float64}
+
+    RightBoundary(λseq) =
+        isin(λseq, 0., 1.) ? new(λseq) : throw(DomainError())
+end
+
+# λseq used in Liang, Nettleton 2012
+RightBoundary() = RightBoundary([collect(0.02:0.02:0.1); collect(0.15:0.05:0.95)])
+
+function estimate_pi0{T<:AbstractFloat}(pValues::Vector{T}, pi0estimator::RightBoundary)
+    rightboundary_pi0(pValues, pi0estimator.λseq)
+end
+
+function rightboundary_pi0{T<:AbstractFloat}(pValues::Vector{T}, λseq)
+    validPValues(pValues)
+    n = length(pValues)
+    if !issorted(λseq)
+        λseq = sort(λseq)
+    end
+    # make sure we catch p-values equal to 1 despite left closure
+    # use closed=:left because we have been using >= convention in this package
+    # note that original paper uses > convention.
+    h = fit(Histogram, pValues, [λseq; 1.1], closed=:left)
+    pi0_estimates = reverse(cumsum(reverse(h.weights)))./(1. -λseq)./n
+    pi0_decrease = diff(pi0_estimates) .>= 0
+    pi0_decrease[end] = true
+    pi0 = pi0_estimates[findfirst(pi0_decrease, true) + 1]
+    return(min(pi0,1))
+end

--- a/test/test-pi0-estimators.jl
+++ b/test/test-pi0-estimators.jl
@@ -137,4 +137,41 @@ p_unsort = unsort(p)
 @test_approx_eq twostep_pi0(p_unsort, alpha) 0.665
 @test !issorted(p_unsort)
 
+
+## rightboundary_pi0 ##
+println(" ** ", "rightboundary_pi0")
+
+# R code tested against (note this uses equidistant grid so we have to use
+# λseq as in Storey for comparison
+
+# library(pi0)
+# p0 <- seq(0.01,1, by=0.01)
+# histf1(p0, rightBoundary=TRUE)
+# [1] 1
+# p1 <- p0^10
+# histf1(p1, rightBoundary=TRUE)
+# [1] 0.1428571
+# p <- c(p0,p1)# histf1(p, rightBoundary=TRUE)
+# [1] 0.5714286
+
+# only eps because pi0 package uses right closed histograms
+@test_approx_eq_eps rightboundary_pi0(p,  lambdas) 0.5714286 0.02
+@test_approx_eq rightboundary_pi0(p0, lambdas) 1.0
+@test_approx_eq_eps rightboundary_pi0(p1, lambdas) 0.1428571 10.0^(-7)
+
+@test issubtype(typeof(RightBoundary(lambdas)), Pi0Estimator)
+@test_approx_eq_eps estimate_pi0(p,  RightBoundary(lambdas)) 0.5714286 0.02
+@test_approx_eq estimate_pi0(p0, RightBoundary(lambdas)) 1.0
+@test_approx_eq_eps estimate_pi0(p1, RightBoundary(lambdas)) 0.1428571 10.0^(-7)
+
+# not checked against R implementation but should hold (check for default lambda grid)
+@test_approx_eq estimate_pi0(p0, RightBoundary()) 1.0
+
+@test issubtype(typeof(RightBoundary()), Pi0Estimator)
+
+p_unsort = unsort(p1)
+@test !issorted(p_unsort)
+@test_approx_eq_eps rightboundary_pi0(p_unsort, lambdas) 0.1428571 10.0^(-7)
+@test !issorted(p_unsort)
+
 end


### PR DESCRIPTION
An efficient implementation of the RightBoundary pi0 estimator proposed in "Adaptive and dynamic adaptive procedures for false discovery rate control and estimation" (Liang and Netteleton, 2012). My favorite estimator (because of stability) is the LSL estimator and according to the authors this one retains the good properties of LSL and at the same time is less conservative.

The algorithm is described below (screenshot from paper):

<img width="628" alt="screen shot 2016-01-07 at 8 38 18 pm" src="https://cloud.githubusercontent.com/assets/2933625/12181209/21f0749c-b581-11e5-83ee-d46518161989.png">

Here π0(λ) refers to Storey's estimator with parameter λ.

Only found a R implementation with equidistant grid and which defines Storey's estimator using ">" rather than ">=", so cannot perfectly test this. (?)