### PR TITLE
Improve CBUM/BUM estimators

### DIFF
--- a/src/pi0-estimators.jl
+++ b/src/pi0-estimators.jl
@@ -231,7 +231,7 @@ type CensoredBUM <: Pi0Estimator
     maxiter::Int64
 
     function CensoredBUM(γ0, λ, xtol, maxiter)
-        if isin(γ0, 0., 1.) && isin(λ, 0., 1.) && isin(xtol, 0., 1.)
+        if isin(γ0, 0., 1.) && isin(λ, 0., 1.) && isin(xtol, 0., 1.) && maxiter > 0
             new(γ0, λ, xtol, maxiter)
         else
             throw(DomainError())
@@ -240,6 +240,7 @@ type CensoredBUM <: Pi0Estimator
 end
 
 CensoredBUM() = CensoredBUM(0.5, 0.05, 1e-6, 10000)
+CensoredBUM(γ0, λ) = CensoredBUM(γ0, λ, 1e-6, 10000)
 
 type CensoredBUMFit <: Pi0Fit
     π0::Float64
@@ -249,30 +250,23 @@ end
 
 function fit(pi0estimator::CensoredBUM, pValues;
              kw...)
-    π0, param, is_converged = cbum_pi0(pValues, pi0estimator.γ0,  pi0estimator.λ,
+    π0, param, is_converged = cbum_pi0(pValues, pi0estimator.γ0, pi0estimator.λ,
                                        pi0estimator.xtol, pi0estimator.maxiter;
                                        kw...)
     return CensoredBUMFit(π0, param, is_converged)
 end
 
-function estimate_pi0{T<:AbstractFloat}(pValues::Vector{T}, pi0estimator::CensoredBUM;
-                                        verbose = false)
-    estimate_pi0(fit(pi0estimator, pValues, verbose = verbose))
+function estimate_pi0{T<:AbstractFloat}(pValues::Vector{T}, pi0estimator::CensoredBUM)
+    estimate_pi0(fit(pi0estimator, pValues))
 end
 
 function estimate_pi0(pi0fit::CensoredBUMFit)
-    if pi0fit.is_converged
-        π0 = pi0fit.π0
-    else
-        π0 = NaN
-        warn("Estimation did not converge")
-    end
+    π0 = pi0fit.is_converged ? π0 = pi0fit.π0 : NaN
     return π0
 end
 
 function cbum_pi0{T<:AbstractFloat}(pValues::Vector{T}, γ0::T = 0.5, λ::T = 0.05,
-                                    xtol::Float64 = 1e-6, maxiter::Int = 10000;
-                                    verbose::Bool = false)
+                                    xtol::Float64 = 1e-6, maxiter::Int = 10000)
     n = length(pValues)
     idx_right = pValues .>= λ
     n2 = sum(idx_right)
@@ -285,7 +279,7 @@ function cbum_pi0{T<:AbstractFloat}(pValues::Vector{T}, γ0::T = 0.5, λ::T = 0.
     lpr = log(pr)
     ll = log(λ)
     zr = fill(1-γ0, n2)
-    γ0 = α = γ = Inf
+    pi0_old = γ0 = α = γ = Inf
     for i in 1:maxiter
         γ = 1 - sz/n
         α = -szr / ( ll * szl + sum(zr .* lpr) )
@@ -297,26 +291,23 @@ function cbum_pi0{T<:AbstractFloat}(pValues::Vector{T}, γ0::T = 0.5, λ::T = 0.
         zr = xr ./ (γ + xr)
         szr = sum(zr)
         sz = szl + szr
-        if verbose
-            cbum_verbose(i, α, γ)
-        end
-        if abs(γ - γ0) <= xtol
-            pi0 = γ + (1-γ)*α
-            return pi0, [γ, α], true
+        pi0_new = γ + (1-γ)*α
+        if abs(pi0_new - pi0_old) <= xtol
+            return pi0_new, [γ, α], true
         end
         γ0 = γ
+        pi0_old = pi0_new
     end
     return NaN, [γ, α], false
 end
 
 function cbum_pi0_naive(pValues, γ0 = 0.5, λ = 0.05,
-                        xtol = 1e-6, maxiter = 10000;
-                        verbose = false)
+                        xtol = 1e-6, maxiter = 10000)
     n = length(pValues)
     z = fill(1-γ0, n)
     idx_left = pValues .< λ
     idx_right = !idx_left
-    γ0 = α = γ = Inf
+    pi0_old = γ0 = α = γ = Inf
     ## compute constant values only once
     lpr = log(pValues[idx_right])
     ll = log(λ)
@@ -328,19 +319,15 @@ function cbum_pi0_naive(pValues, γ0 = 0.5, λ = 0.05,
         z[idx_left] = xl ./ (γ*λ + xl)
         xr = (1-γ) * α * pValues[idx_right].^(α-1)
         z[idx_right] = xr ./ (γ + xr)
-        if verbose
-            cbum_verbose(i, α, γ)
-        end
-        if abs(γ - γ0) <= xtol
-            pi0 = γ + (1-γ)*α
-            return pi0, [γ, α], true
+        pi0_new = γ + (1-γ)*α
+        if abs(pi0_new - pi0_old) <= xtol
+            return pi0_new, [γ, α], true
         end
         γ0 = γ
+        pi0_old = pi0_new
     end
     return NaN, [γ, α], false
 end
-
-@eval cbum_verbose(i, α, γ) = @printf("Iteration: %d\tα: %g\tγ: %g\n", i, α, γ)
 
 
 ## BUM
@@ -375,23 +362,17 @@ end
 
 function fit(pi0estimator::BUM, pValues;
              kw...)
-    π0, param, is_converged = cbum_pi0(pValues, pi0estimator.γ0,  eps(),
+    π0, param, is_converged = cbum_pi0(pValues, pi0estimator.γ0, eps(),
                                        pi0estimator.xtol, pi0estimator.maxiter;
                                        kw...)
     return BUMFit(π0, param, is_converged)
 end
 
-function estimate_pi0{T<:AbstractFloat}(pValues::Vector{T}, pi0estimator::BUM;
-                                        verbose = false)
-    estimate_pi0(fit(pi0estimator, pValues, verbose = verbose))
+function estimate_pi0{T<:AbstractFloat}(pValues::Vector{T}, pi0estimator::BUM)
+    estimate_pi0(fit(pi0estimator, pValues))
 end
 
 function estimate_pi0(pi0fit::BUMFit)
-    if pi0fit.is_converged
-        π0 = pi0fit.π0
-    else
-        π0 = NaN
-        warn("Estimation did not converge")
-    end
+    π0 = pi0fit.is_converged ? π0 = pi0fit.π0 : NaN
     return π0
 end

--- a/test/test-pi0-estimators.jl
+++ b/test/test-pi0-estimators.jl
@@ -181,27 +181,36 @@ println(" ** ", "censoredBUM_pi0")
 @test_approx_eq_eps estimate_pi0(p, CensoredBUM()) 0.55797 1e-5
 @test_approx_eq estimate_pi0(p, CensoredBUM()) MultipleTesting.cbum_pi0_naive(p)[1]
 @test_approx_eq_eps estimate_pi0(p0, CensoredBUM()) 1.0 1e-5
-@test_approx_eq_eps estimate_pi0(p1, CensoredBUM()) 0.1160817 1e-5
+@test_approx_eq_eps estimate_pi0(p1, CensoredBUM()) 0.11608 2e-5
 @test_approx_eq_eps estimate_pi0(ones(50), CensoredBUM()) 1.0 1e-5
 
-## test if not converging
-#@test isnan(estimate_pi0(p, CensoredBUM(0.5, 0.05, 1e-10, 10)))
+## test case that does not converge
+stderr_dump = redirect_stderr()
+@test isnan(estimate_pi0(p, CensoredBUM(0.5, 0.05, 1e-6, 2)))
 
 @test issubtype(typeof(CensoredBUM()), Pi0Estimator)
+@test issubtype(typeof(CensoredBUM(0.2, 0.1)), Pi0Estimator)
 
-let
-    f = fit(CensoredBUM(), p)
-    @test issubtype(typeof(f), CensoredBUMFit)
-    @test_approx_eq_eps f.π0 0.55797 1e-5
+@test_throws DomainError CensoredBUM(-0.5, 0.05)
+@test_throws DomainError CensoredBUM(1.5, 0.05)
+@test_throws DomainError CensoredBUM(0.5, -0.05)
+@test_throws DomainError CensoredBUM(0.5, 1.05)
 
-    pi0, pars, is_converged = MultipleTesting.cbum_pi0(ones(50))
-    @test_approx_eq pi0 1.0
-    @test is_converged
+@test_throws DomainError CensoredBUM(0.5, 0.05, -1e-6, 100)
+@test_throws DomainError CensoredBUM(0.5, 0.05, 1.1, 100)
+@test_throws DomainError CensoredBUM(0.5, 0.05, 1e-6, -10)
 
-    pi0, pars, is_converged = MultipleTesting.cbum_pi0_naive(ones(50))
-    @test isnan(pi0)
-    @test !is_converged
-end
+f = fit(CensoredBUM(), p)
+@test issubtype(typeof(f), CensoredBUMFit)
+@test_approx_eq_eps f.π0 0.55797 1e-5
+
+pi0_est, pars, is_converged = MultipleTesting.cbum_pi0(ones(50))
+@test_approx_eq pi0_est 1.0
+@test is_converged
+
+pi0_est, pars, is_converged = MultipleTesting.cbum_pi0_naive(ones(50))
+@test isnan(pi0_est)
+@test !is_converged
 
 ## BUM_pi0 ##
 ## needs better test cases and reference values
@@ -212,6 +221,12 @@ println(" ** ", "BUM_pi0")
 @test_approx_eq_eps estimate_pi0(p0, BUM()) 1.0 1e-5
 @test_approx_eq_eps estimate_pi0(p1, BUM()) 0.10874 1e-5
 
+## test case that does not converge
+@test isnan(estimate_pi0(p, BUM(0.5, 1e-6, 2)))
+
 @test issubtype(typeof(BUM()), Pi0Estimator)
+
+@test_throws DomainError BUM(-0.5)
+@test_throws DomainError BUM(1.5)
 
 end


### PR DESCRIPTION
- Change convergence criterium to `π0_new - π0_old > xtol` which should be identifable in all cases
- Extend CBUM constructor and argument checking
- Drop `verbose` output
- Drop warnings in case estimation does not converge
- Simply synthax
- Extend test cases